### PR TITLE
Add optional `.style` to the schema via `restyle`

### DIFF
--- a/lib/forms/Form.js
+++ b/lib/forms/Form.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var formGenerator = require('./generator')
+var restyle = require('restyle')
+    , formGenerator = require('./generator')
     , Component = milo.Component
     , componentsRegistry = milo.registry.components
     , logger = milo.util.logger
     , formRegistry = require('./registry')
-    , async = require('async');
+    , async = require('async')
+    , counter = 1;
 
 
 var FORM_VALIDATION_FAILED_CSS_CLASS = 'has-error';
@@ -168,6 +170,14 @@ function MLForm$$createForm(schema, hostObject, formData, template) {
 
     if (schema.css)
         form.css.config = schema.css;
+
+    // allow schema to define confined CSS per form
+    if (schema.style) {
+        // use already set id if any or fallback to unique id
+        const id = form.el.id || ('ml-form-' + counter++);
+        form.style = restyle('#' + id, schema.style, []);
+        form.el.id = id;
+    }
 
     return form;
 
@@ -495,7 +505,8 @@ function MLForm$getViewPath(modelPath) {
 
 function MLForm$destroy() {
     Component.prototype.destroy.apply(this, arguments);
-
+    // clean up the style related node, if any
+    if (this.style) this.style.remove();
     this._connectors && this._connectors.forEach(milo.minder.destroyConnector);
     this._connectors = null;
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "url": "https://github.com/milojs/milo-ui/issues"
   },
   "dependencies": {
-    "async": "^2.0.1"
+    "async": "^2.0.1",
+    "restyle": "^0.5.1"
   },
   "devDependencies": {
     "brfs": "^1.4.3",


### PR DESCRIPTION
In order to simplify sandboxed styles per form and improve forms possibilities,
there is an optional `style` property that will be applied as CSS contained per each specific form.

The [restyle](https://github.com/WebReflection/restyle) library is well tested and it does that already.
