### PR TITLE
feat: Makes public the onItemDrop function of MLListItem

### DIFF
--- a/dist/milo_ui.bundle.js
+++ b/dist/milo_ui.bundle.js
@@ -1051,7 +1051,9 @@ var MLListItem = module.exports = milo.createComponentClass({
                 'dragenter': { subscriber: onDragHover, context: 'owner' },
                 'dragover': { subscriber: onDragHover, context: 'owner' },
                 'dragleave': { subscriber: onDragOut, context: 'owner' },
-                'drop': { subscriber: onItemDrop, context: 'owner' }
+                'drop': { context: 'owner', subscriber: function() {
+                    this.onItemDrop.apply(this, arguments);
+                }}
             },
             allow: {
                 components: isComponentAllowed
@@ -1063,7 +1065,8 @@ var MLListItem = module.exports = milo.createComponentClass({
         moveItem: MLListItem$moveItem,
         removeItem: MLListItem$removeItem,
         getMetaData: MLListItem$getMetaData,
-        isDropAllowed: MLListItem$isDropAllowed
+        isDropAllowed: MLListItem$isDropAllowed,
+        onItemDrop: MLListItem$onItemDrop
     }
 });
 
@@ -1071,6 +1074,7 @@ var MLListItem = module.exports = milo.createComponentClass({
 function MLListItem$init() {
     MLListItem.super.init.apply(this, arguments);
     this.on('childrenbound', onChildrenBound);
+
 }
 
 
@@ -1113,7 +1117,7 @@ function isComponentAllowed() {
 }
 
 
-function onItemDrop(eventType, event) {
+function MLListItem$onItemDrop(eventType, event) {
     onDragOut.call(this);
     var dt = new DragDrop(event);
     var meta = dt.getComponentMeta();

--- a/lib/components/ListItem.js
+++ b/lib/components/ListItem.js
@@ -19,7 +19,9 @@ var MLListItem = module.exports = milo.createComponentClass({
                 'dragenter': { subscriber: onDragHover, context: 'owner' },
                 'dragover': { subscriber: onDragHover, context: 'owner' },
                 'dragleave': { subscriber: onDragOut, context: 'owner' },
-                'drop': { subscriber: onItemDrop, context: 'owner' }
+                'drop': { context: 'owner', subscriber: function() {
+                    this.onItemDrop.apply(this, arguments);
+                }}
             },
             allow: {
                 components: isComponentAllowed
@@ -31,7 +33,8 @@ var MLListItem = module.exports = milo.createComponentClass({
         moveItem: MLListItem$moveItem,
         removeItem: MLListItem$removeItem,
         getMetaData: MLListItem$getMetaData,
-        isDropAllowed: MLListItem$isDropAllowed
+        isDropAllowed: MLListItem$isDropAllowed,
+        onItemDrop: MLListItem$onItemDrop
     }
 });
 
@@ -81,7 +84,7 @@ function isComponentAllowed() {
 }
 
 
-function onItemDrop(eventType, event) {
+function MLListItem$onItemDrop(eventType, event) {
     onDragOut.call(this);
     var dt = new DragDrop(event);
     var meta = dt.getComponentMeta();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milo-ui",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "UI components and schema-based form generator for [milo.js](https://github.com/milojs/milo) framework",
   "keywords": [
     "framework",


### PR DESCRIPTION
- Previous to this, I could not find anyway to hook into an item drop in a subclass of MLListItem

`isDropAllowed` was already exposed.  But my use-case is that I allow a drop to occur and then inform the user that they cannot drop the item if it doesn't meet some criteria (A failure dialog is only shown to the user once they commit to dropping the item and not before / on drag over)