### PR TITLE
fix: Check form not destroyed after onFormShown event is dispatched

### DIFF
--- a/dist/milo_ui.bundle.js
+++ b/dist/milo_ui.bundle.js
@@ -3193,6 +3193,8 @@ function MLForm$$createForm(schema, hostObject, formData, template) {
     const inspector = hostObject && hostObject.inspector,
         id = form.el.id || ('ml-form-' + counter++),
         onFormShown = function () {
+            if (form.isDestroyed()) return; // It is possible the form was destroyed before this event handler was fired.
+
             // allow schema to define confined CSS per form
             form.style = restyle('#' + id, Object.assign({
                 '.centered-tooltip .form-tooltip-content-wrapper': {

--- a/lib/forms/Form.js
+++ b/lib/forms/Form.js
@@ -182,6 +182,8 @@ function MLForm$$createForm(schema, hostObject, formData, template) {
     const inspector = hostObject && hostObject.inspector,
         id = form.el.id || ('ml-form-' + counter++),
         onFormShown = function () {
+            if (form.isDestroyed()) return; // It is possible the form was destroyed before this event handler was fired.
+
             // allow schema to define confined CSS per form
             form.style = restyle('#' + id, Object.assign({
                 '.centered-tooltip .form-tooltip-content-wrapper': {


### PR DESCRIPTION
 - Async handler means there is a possibility that a form can be destroyed after being shown, but before the "onFormShown" event hander is executed