### PR TITLE
fix: Check if textarea component was destroyed before attempted to startAutoresize

### DIFF
--- a/lib/forms/item_types.js
+++ b/lib/forms/item_types.js
@@ -115,7 +115,11 @@ function processInputListSchema(comp, schema) {
 
 function processTextareaSchema(comp, schema) {
     if (schema.autoresize)
-        _.deferMethod(comp, 'startAutoresize', schema.autoresize);
+        _.defer(function() {
+            if (!comp.isDestroyed()) {
+                comp.startAutoresize(schema.autoresize);
+            }
+        });
 }
 
 


### PR DESCRIPTION
Really only a problem when running tests which can interact with the article faster than Jonny Slowsman.  Still, the fix seems legit as anything can happen in the tick between scheduling `startAutoresize` and executing it.  