### PR TITLE
Fix ISO8601 format date constructor

### DIFF
--- a/lib/components/Date.js
+++ b/lib/components/Date.js
@@ -99,7 +99,7 @@ function fromISO8601Format(dateStr, utc) {
 
         date = new Date(Date.UTC(values[0], values[1], values[2]));
     } else {
-        date = _.toDate((/^\d{4}-\d{2}-\d{2}$/).test(dateStr) ? `${dateStr} 00:00:00` : dateStr);
+        date = _.toDate((/^\d{4}-\d{2}-\d{2}$/).test(dateStr) ? (dateStr + ' 00:00:00') : dateStr);
     }
 
     return date;

--- a/lib/components/Date.js
+++ b/lib/components/Date.js
@@ -99,7 +99,7 @@ function fromISO8601Format(dateStr, utc) {
 
         date = new Date(Date.UTC(values[0], values[1], values[2]));
     } else {
-        date = _.toDate(dateStr);
+        date = _.toDate((/^\d{4}-\d{2}-\d{2}$/).test(dateStr) ? `${dateStr} 00:00:00` : dateStr);
     }
 
     return date;


### PR DESCRIPTION
This fixes a problem in `MLDate` component formatting date in UTC even when local time is required.

When not using UTC dates, the `fromISO8601Format` function does not validate the input, so if the value is `2018-06-07` it will get passed to `Date` constructor.
If this format is passed to a `Date` constructor, it will infer that it needs to be UTC and not local time, as per ISO8601 format requires (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date , `dateString` note).

The fix is to add the time as relative to `00:00:00` in order to get a local time parsed `Date`.

### Related to
http://jira.mol.dmgt.net/browse/MOL-15015